### PR TITLE
Update `Path` to Version `16.2.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,11 @@ build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<36]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - wheel
     - setuptools >=42

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "16.0.0" %}
+{% set version = "16.2.0" %}
 
 package:
   name: path
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/path/path-{{ version }}.tar.gz
-  sha256: 48ddde18c6a15d40233bffeca882b6297a3e3a058903f1d4b52671cb8efd4018
+  sha256: 2de925e8d421f93bcea80d511b81accfb6a7e6b249afa4a5559557b0cf817097
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,19 +12,17 @@ build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [py<36]
 
 requirements:
   host:
     - python
     - pip
     - wheel
-    - setuptools >=42
+    - setuptools >=56
     - setuptools_scm >=3.4.1
     - toml
   run:
     - python >=3.6
-    - importlib_metadata >=0.5  # [py<38]
 
 test:
   imports:


### PR DESCRIPTION
  `path` version `16.2.0`
1. check the upstream
    https://github.com/jaraco/path/tree/v16.2.0

2. check the pinnings
    https://github.com/jaraco/path/blob/v16.2.0/tox.ini
    https://github.com/jaraco/path/blob/v16.2.0/test_path.py
    https://github.com/jaraco/path/blob/v16.2.0/setup.cfg
    https://github.com/jaraco/path/blob/v16.2.0/pytest.ini
    https://github.com/jaraco/path/blob/v16.2.0/pyproject.toml


3. check the changelogs
    https://github.com/jaraco/path/blob/v16.2.0/CHANGES.rst

4. additional research
    https://github.com/conda-forge/path-feedstock/issues

    There are currently no open issues mentioned in `conda-forge` at the time of the review. 

5. verify dev_url
    https://github.com/jaraco/path

6. verify doc_url
    https://path.readthedocs.io/en/latest/

7. pip in the test section
8. veriy the test section
9. additional tests

In order to test the `path` package version `16.2.0` the folowing
command was used:
`conda build path-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `path` to version `16.2.0`
